### PR TITLE
Fixes a break in linux with separate python versions installed on the same system.

### DIFF
--- a/kaldi_active_grammar/utils.py
+++ b/kaldi_active_grammar/utils.py
@@ -72,7 +72,7 @@ class ExternalProcess(object):
     compile_graph_agf = shell(os.path.join(exec_dir, 'compile-graph-agf'))
     compile_graph_agf_debug = shell(os.path.join(exec_dir, 'compile-graph-agf-debug'))
 
-    make_lexicon_fst = shell(['python', os.path.join(os.path.dirname(os.path.abspath(__file__)), 'kaldi', 'make_lexicon_fst%s.py' % ('_py2' if PY2 else ''))])
+    make_lexicon_fst = shell([sys.executable, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'kaldi', 'make_lexicon_fst%s.py' % ('_py2' if PY2 else ''))])
 
     @staticmethod
     def get_formatter(format_kwargs):


### PR DESCRIPTION
Simple fix, using sys.executable. API is common among all python versions to date so there shouldn't be any compat issues.